### PR TITLE
Tighten summaries of recipes' READMEs

### DIFF
--- a/cache-from-zip/README.md
+++ b/cache-from-zip/README.md
@@ -1,5 +1,5 @@
 # Cache from ZIP
-This recipe illustrates how to cache contents from a zipfile.
+Cache contents from a zipfile.
 
 ## Difficulty
 Intermediate

--- a/cache-then-network/README.md
+++ b/cache-then-network/README.md
@@ -1,6 +1,6 @@
 # Cache then Network
 
-This recipe illustrates methods to return network requests from either the cache or network.
+Return network requests from either the cache or network.
 
 ## Difficulty
 Beginner

--- a/dependency-injector/README.md
+++ b/dependency-injector/README.md
@@ -1,5 +1,5 @@
 # Dependency Injection
-This recipe shows how a Service Worker can act as a dependency injector, avoiding _hard wiring_ dependencies for high level components.
+A Service Worker acting as a dependency injector, avoiding _hard wiring_ dependencies for high level components.
 
 ## Difficulty
 Advanced

--- a/fetching/README.md
+++ b/fetching/README.md
@@ -1,6 +1,6 @@
 # Fetching Remote Resources
 
-This recipe shows 2 standard ways of loading a remote resource and one way to use service worker as a proxy middleware.
+2 standard ways of loading a remote resource and one way to use service worker as a proxy middleware.
 
 There are used 3 types of remote resources - unsecure (http), secured with `allow-origin` header, and secured without the header.
 

--- a/immediate-claim/README.md
+++ b/immediate-claim/README.md
@@ -1,6 +1,6 @@
 # Immediate Claim
 
-This recipe shows how to have the service worker immediately take control of the page without waiting for a navigation event.
+A service worker that immediately takes control of the page without waiting for a navigation event.
 
 ## Difficulty
 Beginner

--- a/json-cache/README.md
+++ b/json-cache/README.md
@@ -1,6 +1,6 @@
 # JSON Cache
 
-This recipe illustrates fetching a JSON file during service worker installation and adding all resources to cache.  This recipe also immediately claims the service worker for faster activation.
+Fetching a JSON file during service worker installation and adding all resources to cache, and immediately claiming the service worker for faster activation.
 
 ## Difficulty
 Beginner

--- a/live-flowchart/README.md
+++ b/live-flowchart/README.md
@@ -1,6 +1,6 @@
 # Live Flowchart
 
-This recipe provides a way to learn how to use service workers (SW) through showing [the flow diagram of SW workflow explained on the Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers), and logging on screen the steps taken by a real Web App running service workers.
+A demonstration helping to learn how to use service workers (SW) through showing [the flow diagram of SW workflow explained on the Mozilla Developer Network](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers), and logging on screen the steps taken by a real Web App running service workers.
 
 ## Difficulty
 Advanced

--- a/load-balancer/README.md
+++ b/load-balancer/README.md
@@ -1,5 +1,5 @@
 # Load balancer
-This recipe shows a Service Worker containing network logic to dynamically select the best content provider accordingly to server availability.
+A Service Worker containing network logic to dynamically select the best content provider accordingly to server availability.
 
 ## Difficulty
 Intermediate

--- a/message-relay/README.md
+++ b/message-relay/README.md
@@ -1,6 +1,6 @@
 # Message Relay
 
-This recipe shows how to communicate between the service worker and a page and shows how to use a service worker to relay messages between pages.
+Communicate between the service worker and a page and relay messages between pages.
 
 ## Difficulty
 Beginner

--- a/offline-fallback/README.md
+++ b/offline-fallback/README.md
@@ -1,6 +1,6 @@
 # Offline Fallback
 
-This recipe shows how to serve content from the cache when the user is offline.
+Serve content from the cache when the user is offline.
 
 ## Difficulty
 Beginner

--- a/push-subscription-management/README.md
+++ b/push-subscription-management/README.md
@@ -1,6 +1,6 @@
 # Push Subscription
 
-This recipe shows how to use push notifications with subscription management.
+Use push notifications with subscription management.
 
 ## Difficulty
 Advanced

--- a/request-deferrer/README.md
+++ b/request-deferrer/README.md
@@ -1,5 +1,5 @@
 # Request Deferrer
-This recipe shows how to enqueue requests while in offline in an _outbox-like_ buffer to perform the operations once the connection is regained.
+Enqueue requests while in offline in an _outbox-like_ buffer to perform the operations once the connection is regained.
 
 ## Difficulty
 Advanced

--- a/strategy-network-or-cache/README.md
+++ b/strategy-network-or-cache/README.md
@@ -1,7 +1,6 @@
 # Network or cache
-The service worker in this recipe tries to retrieve the most up to date content
-from the network but if the network is taking too much, it will serve cached
-content instead.
+Retrieve the most up to date content from the network, but if the network is
+taking too much, serve cached content instead.
 
 ## Difficulty
 Beginner

--- a/virtual-server/README.md
+++ b/virtual-server/README.md
@@ -1,5 +1,5 @@
 # Virtual Server
-This recipe shows a service worker acting like a remote server.
+A service worker acting like a remote server.
 
 ## Difficulty
 Intermediate


### PR DESCRIPTION
The recipe's summary repeats phrases like "This recipe tries to make a service worker that" (exaggerated for demonstrative purposes). The summary can be shortened without losing information by employing e. g. an imperative.

Please double check that my changes did not change the meaning of the summaries, as I did not look up the content of each recipe.